### PR TITLE
Support: patterns with no description element

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -20,7 +20,7 @@ function getTagCells(tag) {
 }
 
 function getTriggerText(tag) {
-  return tag.firingTriggers.map(t => t.description).join('\n')
+  return tag.firingTriggers.map(t => t?.description).join('\n')
 }
 
 exports.parse = tags => {


### PR DESCRIPTION
# WHAT
Support patterns with no description, such as GA, for example.